### PR TITLE
Changed the default return type for GetFactionID

### DIFF
--- a/lua/cfcfactions/core/sv/sv_player_ext.lua
+++ b/lua/cfcfactions/core/sv/sv_player_ext.lua
@@ -31,7 +31,7 @@ function meta:GetFactionID()
     if self:IsBot() then return "b0t" end
     if self:IsPlayer() then
         if self:IsInFaction() == false then
-            return 0 
+            return nil
         else 
             return fpm[self:SteamID64()].FactionID
         end


### PR DESCRIPTION
I couldn't find any places where I'd have to change the syntax for `ply:GetFactionID()`, so here's the shortest PR ever for ya!